### PR TITLE
Remove deprecated class map generator documentation

### DIFF
--- a/docs/book/class-map-autoloader.md
+++ b/docs/book/class-map-autoloader.md
@@ -8,7 +8,7 @@ opcode caches and PHP's realpath cache.
 
 ## Quick Start
 
-The first step is to generate a class map file in form of a PHP file returning an
+The first step is to create a class map file in form of a PHP file returning an
 associative array that represents the class map. In this example, the class map
 is located at `Some/Directory/autoload_classmap.php`.
 

--- a/docs/book/class-map-autoloader.md
+++ b/docs/book/class-map-autoloader.md
@@ -6,23 +6,14 @@ the file associated with that class on a match.  This avoids unnecessary
 filesystem operations, and can also ensure the autoloader "plays nice" with
 opcode caches and PHP's realpath cache.
 
-The zend-loader component provides a tool for generating classmaps via
-`bin/classmap_generator.php`; read the [tool's documentation](classmap-generator.md) for more details.
-
 ## Quick Start
 
-The first step is to generate a class map file. You may run this over any
-directory containing source code anywhere underneath it.
+The first step is to generate a class map file in form of a PHP file returning an
+associative array that represents the class map. In this example, the class map
+is located at `Some/Directory/autoload_classmap.php`.
 
-```bash
-$ php classmap_generator.php Some/Directory/
-```
-
-This will create a file named `Some/Directory/autoload_classmap.php`, which is a
-PHP file returning an associative array that represents the class map.
-
-Within your code, you will now instantiate the `ClassMapAutoloader`, and provide
-it the location of the map.
+Within your code, instantiate the `ClassMapAutoloader`, and provide it the
+location of the map.
 
 ```php
 // This example assumes the ClassMapAutoloader is autoloadable.

--- a/docs/book/classmap-generator.md
+++ b/docs/book/classmap-generator.md
@@ -1,5 +1,8 @@
 # The Class Map Generator utility: bin/classmap\_generator.php
 
-The script `bin/classmap_generator.php` has been removed and is no longer available. Instead, we recommend using [Composer for autoloading](https://getcomposer.org/doc/04-schema.md#autoload).
+> ### Removed functionality
+> 
+> The script `bin/classmap_generator.php` has been removed and is no longer available.
+> Instead, we recommend using [Composer for autoloading](https://getcomposer.org/doc/04-schema.md#autoload).
 
 If you are upgrading from an existing Zend Framework v2 application, please refer to the [migration guide](https://docs.zendframework.com/tutorials/migration/to-v3/application/#scripts) for more detailed information.

--- a/docs/book/classmap-generator.md
+++ b/docs/book/classmap-generator.md
@@ -1,28 +1,5 @@
 # The Class Map Generator utility: bin/classmap\_generator.php
 
-The script `bin/classmap_generator.php` can be used to generate class map files for use with the
-[ClassMapAutoloader](class-map-autoloader.md).
+The script `bin/classmap_generator.php` has been removed and is no longer available. Instead, we recommend using [Composer for autoloading](https://getcomposer.org/doc/04-schema.md#autoload).
 
-Internally, it consumes both the [zend-console getopt functionality](https://docs.zendframework.com/zend-console/getopt/intro/)
-(for parsing command-line options) and the [zend-file ClassFileLocator](https://docs.zendframework.com/zend-file/class-file-locator/)
-for recursively finding all PHP class files in a given tree.
-
-## Quick Start
-
-You may run the script over any directory containing source code. By default, it
-will look in the current directory, and will write the script to
-`autoloader_classmap.php` in the directory you specify.
-
-```bash
-$ php classmap_generator.php Some/Directory/
-```
-
-## Configuration Options
-
-Option             | Description
------------------- | -----------
-`--help | -h`      | Returns the usage message. If any other options are provided, they will be ignored.
-`--library | -l`   | Expects a single argument, a string specifying the library directory to parse. If this option is not specified, it will assume the current working directory.
-`--output | -o`    | Where to write the autoload class map file. If not provided, assumes `autoload_classmap.php` in the library directory.
-`--append | -a`    | Append to autoload file if it exists.
-`--overwrite | -w` | If an autoload class map file already exists with the name as specified via the `--output` option, you can overwrite it by specifying this flag. Otherwise, the script will not write the class map and return a warning.
+If you are upgrading from an existing Zend Framework v2 application, please refer to the [migration guide](https://docs.zendframework.com/tutorials/migration/to-v3/application/#scripts) for more detailed information.


### PR DESCRIPTION
This PR removes the documentation of the ZF 2 script `bin/classmap_generator.php`, which never was part of this component.

Instead the usage of Composer for autoloading is suggested and a reference to the migration guide added.